### PR TITLE
Reuse existing samtools .fai index when present

### DIFF
--- a/src/main/java/nl/wur/bis/kcftools/Data/FastaIndex.java
+++ b/src/main/java/nl/wur/bis/kcftools/Data/FastaIndex.java
@@ -25,14 +25,20 @@ public class FastaIndex implements AutoCloseable {
 
     public FastaIndex(String fastaFilePath) throws IOException {
         File fastaFile = new File(fastaFilePath);
-        String faiFilePath = fastaFilePath + ".faidx";
-        File indexFile = new File(faiFilePath);
+        File samtoolsFai = new File(fastaFilePath + ".fai");
+        File indexFile;
 
-        if (!indexFile.exists() || HelperFunctions.isOlder(indexFile, fastaFile)) {
-            Logger.info(CLASS_NAME, "Generating/Updating index file: " + faiFilePath);
-            generateIndexFile(fastaFile, indexFile);
+        if (samtoolsFai.exists() && !HelperFunctions.isOlder(samtoolsFai, fastaFile)) {
+            indexFile = samtoolsFai;
+            Logger.info(CLASS_NAME, "Using existing index file: " + samtoolsFai.getPath());
         } else {
-            Logger.info(CLASS_NAME, "Using existing index file: " + faiFilePath);
+            indexFile = new File(fastaFilePath + ".faidx");
+            if (!indexFile.exists() || HelperFunctions.isOlder(indexFile, fastaFile)) {
+                Logger.info(CLASS_NAME, "Generating/Updating index file: " + indexFile.getPath());
+                generateIndexFile(fastaFile, indexFile);
+            } else {
+                Logger.info(CLASS_NAME, "Using existing index file: " + indexFile.getPath());
+            }
         }
 
         // sort this.index by entry.seqId


### PR DESCRIPTION
First off, thanks for building kcftools and documenting it so thoroughly, it's a pleasure to use.

While running kcftools on FASTA references that already had a samtools .fai index next to them, I noticed we end up with two indexes side by side: the original `.fai` and a parallel .faidx regenerated by kcftools. As far as I can tell these formats are identical. I'd prefer it checks for `.fai` first so kcftools doesn't regenerate it since `.fai` is the format samtools uses, so an index will often already be present

I made a small change, feel free to tweak or rework it however you see fit. FastaIndex now resolves the index in this order:

Use `<fasta>.fai` if it exists and isn't older than the FASTA.
Otherwise, use `<fasta>.faidx` if it exists and isn't older than the FASTA.
Otherwise, generate `<fasta>.faidx` (the existing behaviour).

Existing .faidx files keep working unchanged, so this should be fully backwards compatible.